### PR TITLE
Feature/Observation du multithreading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 Sujet.txt
+**/bin/
+**/obj/
+/markdown

--- a/WS_IPC.sln
+++ b/WS_IPC.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WS_Multithread", "WS_Multithread\WS_Multithread.csproj", "{8A45806D-6B62-4024-A4A8-EF13A601093F}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{8A45806D-6B62-4024-A4A8-EF13A601093F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8A45806D-6B62-4024-A4A8-EF13A601093F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8A45806D-6B62-4024-A4A8-EF13A601093F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{8A45806D-6B62-4024-A4A8-EF13A601093F}.Debug|x64.Build.0 = Debug|Any CPU
+		{8A45806D-6B62-4024-A4A8-EF13A601093F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8A45806D-6B62-4024-A4A8-EF13A601093F}.Debug|x86.Build.0 = Debug|Any CPU
+		{8A45806D-6B62-4024-A4A8-EF13A601093F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8A45806D-6B62-4024-A4A8-EF13A601093F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8A45806D-6B62-4024-A4A8-EF13A601093F}.Release|x64.ActiveCfg = Release|Any CPU
+		{8A45806D-6B62-4024-A4A8-EF13A601093F}.Release|x64.Build.0 = Release|Any CPU
+		{8A45806D-6B62-4024-A4A8-EF13A601093F}.Release|x86.ActiveCfg = Release|Any CPU
+		{8A45806D-6B62-4024-A4A8-EF13A601093F}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/WS_Multithread/Program.cs
+++ b/WS_Multithread/Program.cs
@@ -1,0 +1,30 @@
+using WS_Multithread.Threading;
+
+namespace WS_Multithread;
+
+/// <summary>
+/// Point d'entree de la feature 1 du workshop multithreading.
+/// </summary>
+internal static class Program
+{
+    /// <summary>
+    /// Lance 300 threads executant <see cref="ObservationScenario.FctA(object?)"/>.
+    /// </summary>
+    private static void Main()
+    {
+        var options = new ThreadBatchOptions(
+            threadCount: 300,
+            delayBetweenStartsMilliseconds: 10,
+            simulatedWorkDurationMilliseconds: 30);
+
+        ObservationScenario.ResetCounter();
+        IThreadScenario scenario = new ObservationScenario(options.SimulatedWorkDurationMilliseconds);
+        var runner = new ThreadBatchRunner(options, scenario);
+
+        runner.Run();
+
+        Console.WriteLine();
+        Console.WriteLine(
+            $"Fin d'execution. Valeur finale de _nb_thread_in_progress = {ObservationScenario.CurrentInProgressCount}");
+    }
+}

--- a/WS_Multithread/Threading/IThreadScenario.cs
+++ b/WS_Multithread/Threading/IThreadScenario.cs
@@ -1,0 +1,13 @@
+namespace WS_Multithread.Threading;
+
+/// <summary>
+/// Decrit le traitement execute par chaque thread.
+/// </summary>
+internal interface IThreadScenario
+{
+    /// <summary>
+    /// Execute le scenario de thread.
+    /// </summary>
+    /// <param name="threadState">Etat transmis au thread lors du demarrage.</param>
+    void Execute(object? threadState);
+}

--- a/WS_Multithread/Threading/ObservationScenario.cs
+++ b/WS_Multithread/Threading/ObservationScenario.cs
@@ -1,0 +1,68 @@
+namespace WS_Multithread.Threading;
+
+/// <summary>
+/// Implemente la partie Observation du sujet.
+/// </summary>
+internal sealed class ObservationScenario : IThreadScenario
+{
+    /// <summary>
+    /// Compteur partage de threads en cours, volontairement non protege pour observer les races.
+    /// </summary>
+    private static int _nb_thread_in_progress = 0;
+
+    private static int _simulatedWorkDurationMilliseconds = 30;
+
+    /// <summary>
+    /// Initialise une nouvelle instance de <see cref="ObservationScenario"/>.
+    /// </summary>
+    /// <param name="simulatedWorkDurationMilliseconds">Delai simule dans la methode FctA.</param>
+    public ObservationScenario(int simulatedWorkDurationMilliseconds)
+    {
+        if (simulatedWorkDurationMilliseconds < 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(simulatedWorkDurationMilliseconds),
+                "Le delai de travail simule ne peut pas etre negatif.");
+        }
+
+        _simulatedWorkDurationMilliseconds = simulatedWorkDurationMilliseconds;
+    }
+
+    /// <summary>
+    /// Obtient la valeur courante du compteur partage.
+    /// </summary>
+    public static int CurrentInProgressCount => _nb_thread_in_progress;
+
+    /// <summary>
+    /// Reinitialise le compteur partage.
+    /// </summary>
+    public static void ResetCounter()
+    {
+        _nb_thread_in_progress = 0;
+    }
+
+    /// <inheritdoc />
+    public void Execute(object? threadState)
+    {
+        FctA(threadState);
+    }
+
+    /// <summary>
+    /// Methode executee par tous les threads de la partie 1.
+    /// </summary>
+    /// <param name="threadState">Nom logique du thread.</param>
+    public static void FctA(object? threadState)
+    {
+        var threadName = threadState as string ?? "Thread_Unknown";
+
+        ++_nb_thread_in_progress;
+        Console.WriteLine(
+            $"[{DateTime.UtcNow:HH:mm:ss.fff}] {threadName} START - in progress: {_nb_thread_in_progress}");
+
+        Thread.Sleep(_simulatedWorkDurationMilliseconds);
+
+        --_nb_thread_in_progress;
+        Console.WriteLine(
+            $"[{DateTime.UtcNow:HH:mm:ss.fff}] {threadName} END   - in progress: {_nb_thread_in_progress}");
+    }
+}

--- a/WS_Multithread/Threading/ThreadBatchOptions.cs
+++ b/WS_Multithread/Threading/ThreadBatchOptions.cs
@@ -1,0 +1,57 @@
+namespace WS_Multithread.Threading;
+
+/// <summary>
+/// Porte la configuration de lancement des threads.
+/// </summary>
+internal sealed class ThreadBatchOptions
+{
+    /// <summary>
+    /// Initialise une nouvelle instance de <see cref="ThreadBatchOptions"/>.
+    /// </summary>
+    /// <param name="threadCount">Nombre total de threads a lancer.</param>
+    /// <param name="delayBetweenStartsMilliseconds">Delai entre deux demarrages de thread.</param>
+    /// <param name="simulatedWorkDurationMilliseconds">Delai de travail simule dans FctA.</param>
+    public ThreadBatchOptions(
+        int threadCount,
+        int delayBetweenStartsMilliseconds,
+        int simulatedWorkDurationMilliseconds)
+    {
+        if (threadCount <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(threadCount), "Le nombre de threads doit etre positif.");
+        }
+
+        if (delayBetweenStartsMilliseconds < 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(delayBetweenStartsMilliseconds),
+                "Le delai entre demarrages ne peut pas etre negatif.");
+        }
+
+        if (simulatedWorkDurationMilliseconds < 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(simulatedWorkDurationMilliseconds),
+                "Le delai de travail simule ne peut pas etre negatif.");
+        }
+
+        ThreadCount = threadCount;
+        DelayBetweenStartsMilliseconds = delayBetweenStartsMilliseconds;
+        SimulatedWorkDurationMilliseconds = simulatedWorkDurationMilliseconds;
+    }
+
+    /// <summary>
+    /// Obtient le nombre total de threads a lancer.
+    /// </summary>
+    public int ThreadCount { get; }
+
+    /// <summary>
+    /// Obtient le delai en millisecondes entre deux demarrages de thread.
+    /// </summary>
+    public int DelayBetweenStartsMilliseconds { get; }
+
+    /// <summary>
+    /// Obtient le delai de travail simule dans FctA.
+    /// </summary>
+    public int SimulatedWorkDurationMilliseconds { get; }
+}

--- a/WS_Multithread/Threading/ThreadBatchRunner.cs
+++ b/WS_Multithread/Threading/ThreadBatchRunner.cs
@@ -1,0 +1,51 @@
+namespace WS_Multithread.Threading;
+
+/// <summary>
+/// Orchestre le lancement et l'attente d'un lot de threads.
+/// </summary>
+internal sealed class ThreadBatchRunner
+{
+    private readonly ThreadBatchOptions _options;
+    private readonly IThreadScenario _scenario;
+
+    /// <summary>
+    /// Initialise une nouvelle instance de <see cref="ThreadBatchRunner"/>.
+    /// </summary>
+    /// <param name="options">Configuration de lancement des threads.</param>
+    /// <param name="scenario">Scenario execute par chaque thread.</param>
+    public ThreadBatchRunner(ThreadBatchOptions options, IThreadScenario scenario)
+    {
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _scenario = scenario ?? throw new ArgumentNullException(nameof(scenario));
+    }
+
+    /// <summary>
+    /// Lance tous les threads puis attend leur fin d'execution.
+    /// </summary>
+    public void Run()
+    {
+        var threads = new List<Thread>(_options.ThreadCount);
+
+        for (var index = 1; index <= _options.ThreadCount; index++)
+        {
+            var threadName = $"Thread_{index:D3}";
+            var thread = new Thread(_scenario.Execute)
+            {
+                Name = threadName
+            };
+
+            threads.Add(thread);
+            thread.Start(threadName);
+
+            if (_options.DelayBetweenStartsMilliseconds > 0)
+            {
+                Thread.Sleep(_options.DelayBetweenStartsMilliseconds);
+            }
+        }
+
+        foreach (var thread in threads)
+        {
+            thread.Join();
+        }
+    }
+}

--- a/WS_Multithread/WS_Multithread.csproj
+++ b/WS_Multithread/WS_Multithread.csproj
@@ -1,0 +1,10 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
# Observation du multithreading

## Resume
Cette PR implemente la partie 1 du sujet: observation des effets de concurrence lorsqu'une methode est executee simultanement par 300 threads sans synchronisation.

## Ce qui a ete fait
- Creation de la solution `WS_IPC` et du projet console `WS_Multithread`.
- Mise en place d'une architecture orientee objet:
  - `ThreadBatchOptions` pour la configuration.
  - `ThreadBatchRunner` pour orchestrer le lancement et l'attente des threads.
  - `IThreadScenario` pour separer le comportement metier du mecanisme de lancement.
  - `ObservationScenario` pour la logique de la partie 1.
- Ajout de l'attribut statique `_nb_thread_in_progress` initialise a `0`.
- Ajout de la methode statique `FctA(object?)` avec:
  - increment/decrement non proteges,
  - `Sleep` parametre,
  - logs `START/END` avec le nom du thread.
- Lancement de 300 threads nommes `Thread_001` a `Thread_300` avec 10 ms entre chaque demarrage.
- Affichage de la valeur finale du compteur partage en fin d'execution.
- Ajout de commentaires XML pour respecter les conventions de commentaire C#.

## Verification
- Commande executee: `dotnet build WS_IPC.sln`
- Resultat attendu: build reussi sans erreur.
