### PR TITLE
Feature/ Protection du compteur avec Interlocked

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 Sujet.txt
 **/bin/
 **/obj/
-/markdown
+markdown/

--- a/WS_Multithread/Program.cs
+++ b/WS_Multithread/Program.cs
@@ -3,7 +3,7 @@ using WS_Multithread.Threading;
 namespace WS_Multithread;
 
 /// <summary>
-/// Point d'entree de la feature 1 du workshop multithreading.
+/// Point d'entree de la feature 2 du workshop multithreading.
 /// </summary>
 internal static class Program
 {

--- a/WS_Multithread/Threading/ObservationScenario.cs
+++ b/WS_Multithread/Threading/ObservationScenario.cs
@@ -6,7 +6,7 @@ namespace WS_Multithread.Threading;
 internal sealed class ObservationScenario : IThreadScenario
 {
     /// <summary>
-    /// Compteur partage de threads en cours, volontairement non protege pour observer les races.
+    /// Compteur partage de threads en cours.
     /// </summary>
     private static int _nb_thread_in_progress = 0;
 
@@ -31,14 +31,14 @@ internal sealed class ObservationScenario : IThreadScenario
     /// <summary>
     /// Obtient la valeur courante du compteur partage.
     /// </summary>
-    public static int CurrentInProgressCount => _nb_thread_in_progress;
+    public static int CurrentInProgressCount => Interlocked.CompareExchange(ref _nb_thread_in_progress, 0, 0);
 
     /// <summary>
     /// Reinitialise le compteur partage.
     /// </summary>
     public static void ResetCounter()
     {
-        _nb_thread_in_progress = 0;
+        Interlocked.Exchange(ref _nb_thread_in_progress, 0);
     }
 
     /// <inheritdoc />
@@ -48,21 +48,22 @@ internal sealed class ObservationScenario : IThreadScenario
     }
 
     /// <summary>
-    /// Methode executee par tous les threads de la partie 1.
+    /// Methode executee par tous les threads.
+    /// Les incrementations/decrementations sont atomiques via <see cref="Interlocked"/>.
     /// </summary>
     /// <param name="threadState">Nom logique du thread.</param>
     public static void FctA(object? threadState)
     {
         var threadName = threadState as string ?? "Thread_Unknown";
 
-        ++_nb_thread_in_progress;
+        var countAfterIncrement = Interlocked.Increment(ref _nb_thread_in_progress);
         Console.WriteLine(
-            $"[{DateTime.UtcNow:HH:mm:ss.fff}] {threadName} START - in progress: {_nb_thread_in_progress}");
+            $"[{DateTime.UtcNow:HH:mm:ss.fff}] {threadName} START - in progress: {countAfterIncrement}");
 
         Thread.Sleep(_simulatedWorkDurationMilliseconds);
 
-        --_nb_thread_in_progress;
+        var countAfterDecrement = Interlocked.Decrement(ref _nb_thread_in_progress);
         Console.WriteLine(
-            $"[{DateTime.UtcNow:HH:mm:ss.fff}] {threadName} END   - in progress: {_nb_thread_in_progress}");
+            $"[{DateTime.UtcNow:HH:mm:ss.fff}] {threadName} END   - in progress: {countAfterDecrement}");
     }
 }


### PR DESCRIPTION
# Protection du compteur avec Interlocked

## Resume
Cette PR securise la variable partagee `_nb_thread_in_progress` en remplacant les operations non atomiques par des operations atomiques basees sur `Interlocked`.

## Ce qui a ete fait
- Mise a jour de `ObservationScenario.FctA(object?)`:
  - `Interlocked.Increment(ref _nb_thread_in_progress)` au demarrage,
  - `Interlocked.Decrement(ref _nb_thread_in_progress)` a la fin,
  - utilisation des valeurs retournees par `Interlocked` pour les logs `START/END`.
- Mise a jour de `ObservationScenario.ResetCounter()` avec `Interlocked.Exchange(ref _nb_thread_in_progress, 0)`.
- Mise a jour de `ObservationScenario.CurrentInProgressCount` avec une lecture atomique via `Interlocked.CompareExchange(ref _nb_thread_in_progress, 0, 0)`.
- Ajustement du commentaire XML du point d'entree pour indiquer la feature en cours.

## Verification
- Commande executee: `dotnet build WS_IPC.sln`
- Commande executee: `dotnet run --project WS_Multithread/WS_Multithread.csproj`
- Resultat: compilation reussie et execution complete des threads avec compteur final coherent.

## Perimetre
- Cette PR couvre uniquement la protection du compteur partage avec `Interlocked`.