### PR TITLE
feature/Gestion d'un acces exclusif

### DIFF
--- a/WS_Multithread/Program.cs
+++ b/WS_Multithread/Program.cs
@@ -3,22 +3,38 @@ using WS_Multithread.Threading;
 namespace WS_Multithread;
 
 /// <summary>
-/// Point d'entree de la feature 2 du workshop multithreading.
+/// Point d'entree de la feature 3 du workshop multithreading.
 /// </summary>
 internal static class Program
 {
     /// <summary>
     /// Lance 300 threads executant <see cref="ObservationScenario.FctA(object?)"/>.
     /// </summary>
-    private static void Main()
+    /// <param name="args">Arguments de ligne de commande.</param>
+    /// <remarks>
+    /// Argument supporte:
+    /// <list type="bullet">
+    /// <item><description><c>--mode lock|monitor|mutex|none</c>.</description></item>
+    /// </list>
+    /// </remarks>
+    private static void Main(string[] args)
     {
+        var exclusiveMode = ExclusiveAccessModeParser.Parse(args);
+        using var exclusiveAccessPrimitive = ExclusiveAccessPrimitiveFactory.Create(exclusiveMode);
+
         var options = new ThreadBatchOptions(
             threadCount: 300,
             delayBetweenStartsMilliseconds: 10,
             simulatedWorkDurationMilliseconds: 30);
 
         ObservationScenario.ResetCounter();
-        IThreadScenario scenario = new ObservationScenario(options.SimulatedWorkDurationMilliseconds);
+        ObservationScenario.ResetExclusiveAccessCounter();
+
+        Console.WriteLine($"Mode d'acces exclusif: {exclusiveAccessPrimitive.Name}");
+
+        IThreadScenario scenario = new ObservationScenario(
+            options.SimulatedWorkDurationMilliseconds,
+            exclusiveAccessPrimitive);
         var runner = new ThreadBatchRunner(options, scenario);
 
         runner.Run();
@@ -26,5 +42,7 @@ internal static class Program
         Console.WriteLine();
         Console.WriteLine(
             $"Fin d'execution. Valeur finale de _nb_thread_in_progress = {ObservationScenario.CurrentInProgressCount}");
+        Console.WriteLine(
+            $"Fin d'execution. Valeur finale de _CountExclusive_access = {ObservationScenario.CurrentExclusiveAccessCount}");
     }
 }

--- a/WS_Multithread/Threading/ExclusiveAccessMode.cs
+++ b/WS_Multithread/Threading/ExclusiveAccessMode.cs
@@ -1,0 +1,27 @@
+namespace WS_Multithread.Threading;
+
+/// <summary>
+/// Repertorie les primitives disponibles pour la section d'acces exclusif.
+/// </summary>
+internal enum ExclusiveAccessMode
+{
+    /// <summary>
+    /// Aucun mecanisme d'acces exclusif.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// Synchronisation via mot-cle <c>lock</c>.
+    /// </summary>
+    Lock = 1,
+
+    /// <summary>
+    /// Synchronisation via classe <see cref="Monitor"/>.
+    /// </summary>
+    Monitor = 2,
+
+    /// <summary>
+    /// Synchronisation via <see cref="Mutex"/>.
+    /// </summary>
+    Mutex = 3
+}

--- a/WS_Multithread/Threading/ExclusiveAccessModeParser.cs
+++ b/WS_Multithread/Threading/ExclusiveAccessModeParser.cs
@@ -1,0 +1,59 @@
+namespace WS_Multithread.Threading;
+
+/// <summary>
+/// Parse les arguments de ligne de commande pour choisir la primitive d'acces exclusif.
+/// </summary>
+internal static class ExclusiveAccessModeParser
+{
+    /// <summary>
+    /// Extrait le mode d'acces exclusif depuis la ligne de commande.
+    /// </summary>
+    /// <param name="args">Arguments du programme.</param>
+    /// <returns>Mode d'acces exclusif selectionne.</returns>
+    /// <exception cref="ArgumentException">L'argument <c>--mode</c> est invalide.</exception>
+    public static ExclusiveAccessMode Parse(string[] args)
+    {
+        if (args is null)
+        {
+            throw new ArgumentNullException(nameof(args));
+        }
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+
+            if (argument.StartsWith("--mode=", StringComparison.OrdinalIgnoreCase))
+            {
+                var modeValue = argument["--mode=".Length..];
+                return ParseModeValue(modeValue);
+            }
+
+            if (string.Equals(argument, "--mode", StringComparison.OrdinalIgnoreCase))
+            {
+                if (index + 1 >= args.Length)
+                {
+                    throw new ArgumentException("L'argument --mode requiert une valeur.");
+                }
+
+                return ParseModeValue(args[index + 1]);
+            }
+        }
+
+        return ExclusiveAccessMode.Lock;
+    }
+
+    private static ExclusiveAccessMode ParseModeValue(string modeValue)
+    {
+        var normalizedMode = modeValue.Trim().ToLowerInvariant();
+
+        return normalizedMode switch
+        {
+            "none" => ExclusiveAccessMode.None,
+            "lock" => ExclusiveAccessMode.Lock,
+            "monitor" => ExclusiveAccessMode.Monitor,
+            "mutex" => ExclusiveAccessMode.Mutex,
+            _ => throw new ArgumentException(
+                $"Mode d'acces exclusif invalide: '{modeValue}'. Valeurs attendues: none, lock, monitor, mutex.")
+        };
+    }
+}

--- a/WS_Multithread/Threading/ExclusiveAccessPrimitiveFactory.cs
+++ b/WS_Multithread/Threading/ExclusiveAccessPrimitiveFactory.cs
@@ -1,0 +1,26 @@
+namespace WS_Multithread.Threading;
+
+/// <summary>
+/// Fabrique de primitives de synchronisation pour la section d'acces exclusif.
+/// </summary>
+internal static class ExclusiveAccessPrimitiveFactory
+{
+    private const string CrossProcessMutexName = @"Global\WS_IPC_ExclusiveAccess_Mutex";
+
+    /// <summary>
+    /// Cree la primitive de synchronisation correspondant au mode demande.
+    /// </summary>
+    /// <param name="mode">Mode d'acces exclusif.</param>
+    /// <returns>Primitive de synchronisation.</returns>
+    public static IExclusiveAccessPrimitive Create(ExclusiveAccessMode mode)
+    {
+        return mode switch
+        {
+            ExclusiveAccessMode.None => new NoSynchronizationExclusiveAccessPrimitive(),
+            ExclusiveAccessMode.Lock => new LockExclusiveAccessPrimitive(),
+            ExclusiveAccessMode.Monitor => new MonitorExclusiveAccessPrimitive(),
+            ExclusiveAccessMode.Mutex => new MutexExclusiveAccessPrimitive(CrossProcessMutexName),
+            _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, "Mode d'acces exclusif non supporte.")
+        };
+    }
+}

--- a/WS_Multithread/Threading/IExclusiveAccessPrimitive.cs
+++ b/WS_Multithread/Threading/IExclusiveAccessPrimitive.cs
@@ -1,0 +1,18 @@
+namespace WS_Multithread.Threading;
+
+/// <summary>
+/// Definit une primitive capable de serialiser l'acces a une section critique.
+/// </summary>
+internal interface IExclusiveAccessPrimitive : IDisposable
+{
+    /// <summary>
+    /// Obtient le nom lisible de la primitive.
+    /// </summary>
+    string Name { get; }
+
+    /// <summary>
+    /// Execute une section critique avec la strategie de synchronisation courante.
+    /// </summary>
+    /// <param name="criticalSection">Code de la section critique.</param>
+    void ExecuteExclusive(Action criticalSection);
+}

--- a/WS_Multithread/Threading/LockExclusiveAccessPrimitive.cs
+++ b/WS_Multithread/Threading/LockExclusiveAccessPrimitive.cs
@@ -1,0 +1,32 @@
+namespace WS_Multithread.Threading;
+
+/// <summary>
+/// Implante l'acces exclusif avec le mot-cle <c>lock</c>.
+/// </summary>
+internal sealed class LockExclusiveAccessPrimitive : IExclusiveAccessPrimitive
+{
+    private readonly object _syncRoot = new();
+
+    /// <inheritdoc />
+    public string Name => "lock";
+
+    /// <inheritdoc />
+    public void ExecuteExclusive(Action criticalSection)
+    {
+        if (criticalSection is null)
+        {
+            throw new ArgumentNullException(nameof(criticalSection));
+        }
+
+        lock (_syncRoot)
+        {
+            criticalSection();
+        }
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        // Aucun objet natif a liberer.
+    }
+}

--- a/WS_Multithread/Threading/MonitorExclusiveAccessPrimitive.cs
+++ b/WS_Multithread/Threading/MonitorExclusiveAccessPrimitive.cs
@@ -1,0 +1,42 @@
+namespace WS_Multithread.Threading;
+
+/// <summary>
+/// Implante l'acces exclusif avec <see cref="Monitor"/>.
+/// </summary>
+internal sealed class MonitorExclusiveAccessPrimitive : IExclusiveAccessPrimitive
+{
+    private readonly object _syncRoot = new();
+
+    /// <inheritdoc />
+    public string Name => "monitor";
+
+    /// <inheritdoc />
+    public void ExecuteExclusive(Action criticalSection)
+    {
+        if (criticalSection is null)
+        {
+            throw new ArgumentNullException(nameof(criticalSection));
+        }
+
+        var lockTaken = false;
+
+        try
+        {
+            Monitor.Enter(_syncRoot, ref lockTaken);
+            criticalSection();
+        }
+        finally
+        {
+            if (lockTaken)
+            {
+                Monitor.Exit(_syncRoot);
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        // Aucun objet natif a liberer.
+    }
+}

--- a/WS_Multithread/Threading/MutexExclusiveAccessPrimitive.cs
+++ b/WS_Multithread/Threading/MutexExclusiveAccessPrimitive.cs
@@ -1,0 +1,65 @@
+namespace WS_Multithread.Threading;
+
+/// <summary>
+/// Implante l'acces exclusif avec un <see cref="Mutex"/> nomme.
+/// </summary>
+internal sealed class MutexExclusiveAccessPrimitive : IExclusiveAccessPrimitive
+{
+    private readonly Mutex _mutex;
+
+    /// <summary>
+    /// Initialise une nouvelle instance de <see cref="MutexExclusiveAccessPrimitive"/>.
+    /// </summary>
+    /// <param name="mutexName">Nom du mutex partage entre processus.</param>
+    public MutexExclusiveAccessPrimitive(string mutexName)
+    {
+        if (string.IsNullOrWhiteSpace(mutexName))
+        {
+            throw new ArgumentException("Le nom du mutex est obligatoire.", nameof(mutexName));
+        }
+
+        _mutex = new Mutex(initiallyOwned: false, name: mutexName);
+    }
+
+    /// <inheritdoc />
+    public string Name => "mutex";
+
+    /// <inheritdoc />
+    public void ExecuteExclusive(Action criticalSection)
+    {
+        if (criticalSection is null)
+        {
+            throw new ArgumentNullException(nameof(criticalSection));
+        }
+
+        var ownsMutex = false;
+
+        try
+        {
+            try
+            {
+                ownsMutex = _mutex.WaitOne();
+            }
+            catch (AbandonedMutexException)
+            {
+                // Le mutex est considere acquis par ce thread.
+                ownsMutex = true;
+            }
+
+            criticalSection();
+        }
+        finally
+        {
+            if (ownsMutex)
+            {
+                _mutex.ReleaseMutex();
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        _mutex.Dispose();
+    }
+}

--- a/WS_Multithread/Threading/NoSynchronizationExclusiveAccessPrimitive.cs
+++ b/WS_Multithread/Threading/NoSynchronizationExclusiveAccessPrimitive.cs
@@ -1,0 +1,27 @@
+namespace WS_Multithread.Threading;
+
+/// <summary>
+/// N'applique aucune synchronisation sur la section critique.
+/// </summary>
+internal sealed class NoSynchronizationExclusiveAccessPrimitive : IExclusiveAccessPrimitive
+{
+    /// <inheritdoc />
+    public string Name => "none";
+
+    /// <inheritdoc />
+    public void ExecuteExclusive(Action criticalSection)
+    {
+        if (criticalSection is null)
+        {
+            throw new ArgumentNullException(nameof(criticalSection));
+        }
+
+        criticalSection();
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        // Aucun objet natif a liberer.
+    }
+}

--- a/WS_Multithread/Threading/ObservationScenario.cs
+++ b/WS_Multithread/Threading/ObservationScenario.cs
@@ -1,7 +1,7 @@
 namespace WS_Multithread.Threading;
 
 /// <summary>
-/// Implemente la partie Observation du sujet.
+/// Implemente la partie Observation et acces exclusif du sujet.
 /// </summary>
 internal sealed class ObservationScenario : IThreadScenario
 {
@@ -10,13 +10,22 @@ internal sealed class ObservationScenario : IThreadScenario
     /// </summary>
     private static int _nb_thread_in_progress = 0;
 
+    /// <summary>
+    /// Compteur de threads presents dans la section d'acces exclusif.
+    /// </summary>
+    private static int _CountExclusive_access = 0;
+
     private static int _simulatedWorkDurationMilliseconds = 30;
+    private static IExclusiveAccessPrimitive? _exclusiveAccessPrimitive;
 
     /// <summary>
     /// Initialise une nouvelle instance de <see cref="ObservationScenario"/>.
     /// </summary>
     /// <param name="simulatedWorkDurationMilliseconds">Delai simule dans la methode FctA.</param>
-    public ObservationScenario(int simulatedWorkDurationMilliseconds)
+    /// <param name="exclusiveAccessPrimitive">Primitive de synchronisation a utiliser pour l'acces exclusif.</param>
+    public ObservationScenario(
+        int simulatedWorkDurationMilliseconds,
+        IExclusiveAccessPrimitive exclusiveAccessPrimitive)
     {
         if (simulatedWorkDurationMilliseconds < 0)
         {
@@ -25,6 +34,8 @@ internal sealed class ObservationScenario : IThreadScenario
                 "Le delai de travail simule ne peut pas etre negatif.");
         }
 
+        _exclusiveAccessPrimitive = exclusiveAccessPrimitive
+            ?? throw new ArgumentNullException(nameof(exclusiveAccessPrimitive));
         _simulatedWorkDurationMilliseconds = simulatedWorkDurationMilliseconds;
     }
 
@@ -34,11 +45,24 @@ internal sealed class ObservationScenario : IThreadScenario
     public static int CurrentInProgressCount => Interlocked.CompareExchange(ref _nb_thread_in_progress, 0, 0);
 
     /// <summary>
+    /// Obtient la valeur courante du compteur d'acces exclusif.
+    /// </summary>
+    public static int CurrentExclusiveAccessCount => _CountExclusive_access;
+
+    /// <summary>
     /// Reinitialise le compteur partage.
     /// </summary>
     public static void ResetCounter()
     {
         Interlocked.Exchange(ref _nb_thread_in_progress, 0);
+    }
+
+    /// <summary>
+    /// Reinitialise le compteur de la section d'acces exclusif.
+    /// </summary>
+    public static void ResetExclusiveAccessCounter()
+    {
+        _CountExclusive_access = 0;
     }
 
     /// <inheritdoc />
@@ -58,12 +82,41 @@ internal sealed class ObservationScenario : IThreadScenario
 
         var countAfterIncrement = Interlocked.Increment(ref _nb_thread_in_progress);
         Console.WriteLine(
-            $"[{DateTime.UtcNow:HH:mm:ss.fff}] {threadName} START - in progress: {countAfterIncrement}");
+            $"[{DateTime.UtcNow:HH:mm:ss.fff}] P{Environment.ProcessId} {threadName} START - in progress: {countAfterIncrement}");
 
-        Thread.Sleep(_simulatedWorkDurationMilliseconds);
+        Fct_Exclusive_access(threadName);
 
         var countAfterDecrement = Interlocked.Decrement(ref _nb_thread_in_progress);
         Console.WriteLine(
-            $"[{DateTime.UtcNow:HH:mm:ss.fff}] {threadName} END   - in progress: {countAfterDecrement}");
+            $"[{DateTime.UtcNow:HH:mm:ss.fff}] P{Environment.ProcessId} {threadName} END   - in progress: {countAfterDecrement}");
+    }
+
+    /// <summary>
+    /// Section de code necessitant un acces exclusif.
+    /// </summary>
+    /// <param name="threadName">Nom logique du thread.</param>
+    public static void Fct_Exclusive_access(string threadName)
+    {
+        var exclusiveAccessPrimitive = _exclusiveAccessPrimitive
+            ?? throw new InvalidOperationException("La primitive d'acces exclusif n'est pas configuree.");
+
+        exclusiveAccessPrimitive.ExecuteExclusive(
+            () =>
+            {
+                ++_CountExclusive_access;
+                Console.WriteLine(
+                    $"[{DateTime.UtcNow:HH:mm:ss.fff}] P{Environment.ProcessId} {threadName} ENTER - exclusive count: {_CountExclusive_access}");
+
+                try
+                {
+                    Thread.Sleep(_simulatedWorkDurationMilliseconds);
+                }
+                finally
+                {
+                    --_CountExclusive_access;
+                    Console.WriteLine(
+                        $"[{DateTime.UtcNow:HH:mm:ss.fff}] P{Environment.ProcessId} {threadName} EXIT  - exclusive count: {_CountExclusive_access}");
+                }
+            });
     }
 }


### PR DESCRIPTION
# Gestion d'un acces exclusif

## Resume
Cette PR introduit une section critique `Fct_Exclusive_access` et ajoute trois primitives de synchronisation (`lock`, `Monitor`, `Mutex`) selectionnables a l'execution.

## Ce qui a ete fait
- Ajout du compteur statique `_CountExclusive_access` dans `ObservationScenario`.
- Ajout de la methode `Fct_Exclusive_access(string)` et appel depuis `FctA(object?)`.
- Remplacement du `Sleep` direct dans `FctA` par l'execution de la section critique.
- Ajout de l'interface `IExclusiveAccessPrimitive` pour abstraire la synchronisation.
- Ajout des implementations:
- `LockExclusiveAccessPrimitive`.
- `MonitorExclusiveAccessPrimitive`.
- `MutexExclusiveAccessPrimitive` avec mutex nomme inter-processus.
- `NoSynchronizationExclusiveAccessPrimitive` pour execution sans protection.
- Ajout de `ExclusiveAccessMode`, `ExclusiveAccessPrimitiveFactory` et `ExclusiveAccessModeParser`.
- Mise a jour de `Program` pour accepter `--mode lock|monitor|mutex|none`.
- Ajout de logs avec PID pour visualiser les executions en multi-instances.

## Verification
- Commande executee: `dotnet build WS_IPC.sln`.
- Commande executee: `dotnet run --project WS_Multithread/WS_Multithread.csproj -- --mode lock`.
- Commande executee: `dotnet run --project WS_Multithread/WS_Multithread.csproj -- --mode monitor`.
- Commande executee: `dotnet run --project WS_Multithread/WS_Multithread.csproj -- --mode mutex`.
- Test multi-instances execute avec deux processus en parallele pour `lock` puis `mutex`.
- Observation: la serialisation est inter-processus avec `mutex` (occupation globale max observee = 1), alors que `lock` ne serialise que dans le processus local (occupation globale max observee = 2).

## Perimetre
- Cette PR couvre uniquement la gestion de l'acces exclusif dans la section critique.