### PR TITLE
Add : Semaphore et cohorte

### DIFF
--- a/WS_Multithread/Program.cs
+++ b/WS_Multithread/Program.cs
@@ -3,7 +3,7 @@ using WS_Multithread.Threading;
 namespace WS_Multithread;
 
 /// <summary>
-/// Point d'entree de la feature 3 du workshop multithreading.
+/// Point d'entree de la feature 4 du workshop multithreading.
 /// </summary>
 internal static class Program
 {
@@ -14,7 +14,7 @@ internal static class Program
     /// <remarks>
     /// Argument supporte:
     /// <list type="bullet">
-    /// <item><description><c>--mode lock|monitor|mutex|none</c>.</description></item>
+    /// <item><description><c>--mode semaphore|lock|monitor|mutex|none</c>.</description></item>
     /// </list>
     /// </remarks>
     private static void Main(string[] args)
@@ -44,5 +44,7 @@ internal static class Program
             $"Fin d'execution. Valeur finale de _nb_thread_in_progress = {ObservationScenario.CurrentInProgressCount}");
         Console.WriteLine(
             $"Fin d'execution. Valeur finale de _CountExclusive_access = {ObservationScenario.CurrentExclusiveAccessCount}");
+        Console.WriteLine(
+            $"Fin d'execution. Valeur max observee de _CountExclusive_access = {ObservationScenario.CurrentMaxExclusiveAccessCount}");
     }
 }

--- a/WS_Multithread/Threading/ExclusiveAccessMode.cs
+++ b/WS_Multithread/Threading/ExclusiveAccessMode.cs
@@ -23,5 +23,10 @@ internal enum ExclusiveAccessMode
     /// <summary>
     /// Synchronisation via <see cref="Mutex"/>.
     /// </summary>
-    Mutex = 3
+    Mutex = 3,
+
+    /// <summary>
+    /// Limitation de cohorte via <see cref="Semaphore"/>.
+    /// </summary>
+    Semaphore = 4
 }

--- a/WS_Multithread/Threading/ExclusiveAccessModeParser.cs
+++ b/WS_Multithread/Threading/ExclusiveAccessModeParser.cs
@@ -39,7 +39,7 @@ internal static class ExclusiveAccessModeParser
             }
         }
 
-        return ExclusiveAccessMode.Lock;
+        return ExclusiveAccessMode.Semaphore;
     }
 
     private static ExclusiveAccessMode ParseModeValue(string modeValue)
@@ -52,8 +52,9 @@ internal static class ExclusiveAccessModeParser
             "lock" => ExclusiveAccessMode.Lock,
             "monitor" => ExclusiveAccessMode.Monitor,
             "mutex" => ExclusiveAccessMode.Mutex,
+            "semaphore" => ExclusiveAccessMode.Semaphore,
             _ => throw new ArgumentException(
-                $"Mode d'acces exclusif invalide: '{modeValue}'. Valeurs attendues: none, lock, monitor, mutex.")
+                $"Mode d'acces invalide: '{modeValue}'. Valeurs attendues: none, lock, monitor, mutex, semaphore.")
         };
     }
 }

--- a/WS_Multithread/Threading/ExclusiveAccessPrimitiveFactory.cs
+++ b/WS_Multithread/Threading/ExclusiveAccessPrimitiveFactory.cs
@@ -6,6 +6,8 @@ namespace WS_Multithread.Threading;
 internal static class ExclusiveAccessPrimitiveFactory
 {
     private const string CrossProcessMutexName = @"Global\WS_IPC_ExclusiveAccess_Mutex";
+    private const string CrossProcessSemaphoreName = @"Global\WS_IPC_Cohort_Semaphore";
+    private const int CohortSize = 3;
 
     /// <summary>
     /// Cree la primitive de synchronisation correspondant au mode demande.
@@ -20,6 +22,9 @@ internal static class ExclusiveAccessPrimitiveFactory
             ExclusiveAccessMode.Lock => new LockExclusiveAccessPrimitive(),
             ExclusiveAccessMode.Monitor => new MonitorExclusiveAccessPrimitive(),
             ExclusiveAccessMode.Mutex => new MutexExclusiveAccessPrimitive(CrossProcessMutexName),
+            ExclusiveAccessMode.Semaphore => new SemaphoreCohortAccessPrimitive(
+                CrossProcessSemaphoreName,
+                CohortSize),
             _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, "Mode d'acces exclusif non supporte.")
         };
     }

--- a/WS_Multithread/Threading/IExclusiveAccessPrimitive.cs
+++ b/WS_Multithread/Threading/IExclusiveAccessPrimitive.cs
@@ -1,7 +1,7 @@
 namespace WS_Multithread.Threading;
 
 /// <summary>
-/// Definit une primitive capable de serialiser l'acces a une section critique.
+/// Definit une primitive capable de controler l'acces a une section critique.
 /// </summary>
 internal interface IExclusiveAccessPrimitive : IDisposable
 {

--- a/WS_Multithread/Threading/ObservationScenario.cs
+++ b/WS_Multithread/Threading/ObservationScenario.cs
@@ -14,6 +14,7 @@ internal sealed class ObservationScenario : IThreadScenario
     /// Compteur de threads presents dans la section d'acces exclusif.
     /// </summary>
     private static int _CountExclusive_access = 0;
+    private static int _MaxCountExclusive_access = 0;
 
     private static int _simulatedWorkDurationMilliseconds = 30;
     private static IExclusiveAccessPrimitive? _exclusiveAccessPrimitive;
@@ -47,7 +48,12 @@ internal sealed class ObservationScenario : IThreadScenario
     /// <summary>
     /// Obtient la valeur courante du compteur d'acces exclusif.
     /// </summary>
-    public static int CurrentExclusiveAccessCount => _CountExclusive_access;
+    public static int CurrentExclusiveAccessCount => Interlocked.CompareExchange(ref _CountExclusive_access, 0, 0);
+
+    /// <summary>
+    /// Obtient le pic d'acces simultanes observe dans la section critique.
+    /// </summary>
+    public static int CurrentMaxExclusiveAccessCount => Interlocked.CompareExchange(ref _MaxCountExclusive_access, 0, 0);
 
     /// <summary>
     /// Reinitialise le compteur partage.
@@ -62,7 +68,8 @@ internal sealed class ObservationScenario : IThreadScenario
     /// </summary>
     public static void ResetExclusiveAccessCounter()
     {
-        _CountExclusive_access = 0;
+        Interlocked.Exchange(ref _CountExclusive_access, 0);
+        Interlocked.Exchange(ref _MaxCountExclusive_access, 0);
     }
 
     /// <inheritdoc />
@@ -92,7 +99,7 @@ internal sealed class ObservationScenario : IThreadScenario
     }
 
     /// <summary>
-    /// Section de code necessitant un acces exclusif.
+    /// Section de code avec acces controle.
     /// </summary>
     /// <param name="threadName">Nom logique du thread.</param>
     public static void Fct_Exclusive_access(string threadName)
@@ -103,9 +110,10 @@ internal sealed class ObservationScenario : IThreadScenario
         exclusiveAccessPrimitive.ExecuteExclusive(
             () =>
             {
-                ++_CountExclusive_access;
+                var countAfterEnter = Interlocked.Increment(ref _CountExclusive_access);
+                UpdateMaxExclusiveAccessCount(countAfterEnter);
                 Console.WriteLine(
-                    $"[{DateTime.UtcNow:HH:mm:ss.fff}] P{Environment.ProcessId} {threadName} ENTER - exclusive count: {_CountExclusive_access}");
+                    $"[{DateTime.UtcNow:HH:mm:ss.fff}] P{Environment.ProcessId} {threadName} ENTER - exclusive count: {countAfterEnter}");
 
                 try
                 {
@@ -113,10 +121,33 @@ internal sealed class ObservationScenario : IThreadScenario
                 }
                 finally
                 {
-                    --_CountExclusive_access;
+                    var countAfterExit = Interlocked.Decrement(ref _CountExclusive_access);
                     Console.WriteLine(
-                        $"[{DateTime.UtcNow:HH:mm:ss.fff}] P{Environment.ProcessId} {threadName} EXIT  - exclusive count: {_CountExclusive_access}");
+                        $"[{DateTime.UtcNow:HH:mm:ss.fff}] P{Environment.ProcessId} {threadName} EXIT  - exclusive count: {countAfterExit}");
                 }
             });
+    }
+
+    private static void UpdateMaxExclusiveAccessCount(int candidate)
+    {
+        while (true)
+        {
+            var currentMax = CurrentMaxExclusiveAccessCount;
+
+            if (candidate <= currentMax)
+            {
+                return;
+            }
+
+            var previousValue = Interlocked.CompareExchange(
+                ref _MaxCountExclusive_access,
+                candidate,
+                currentMax);
+
+            if (previousValue == currentMax)
+            {
+                return;
+            }
+        }
     }
 }

--- a/WS_Multithread/Threading/SemaphoreCohortAccessPrimitive.cs
+++ b/WS_Multithread/Threading/SemaphoreCohortAccessPrimitive.cs
@@ -1,0 +1,66 @@
+namespace WS_Multithread.Threading;
+
+/// <summary>
+/// Limite l'acces a la section critique a un nombre maximal de threads.
+/// </summary>
+internal sealed class SemaphoreCohortAccessPrimitive : IExclusiveAccessPrimitive
+{
+    private readonly Semaphore _semaphore;
+    private readonly int _maxConcurrentUsers;
+
+    /// <summary>
+    /// Initialise une nouvelle instance de <see cref="SemaphoreCohortAccessPrimitive"/>.
+    /// </summary>
+    /// <param name="semaphoreName">Nom du semaphore partage entre processus.</param>
+    /// <param name="maxConcurrentUsers">Nombre maximal d'utilisateurs simultanes.</param>
+    public SemaphoreCohortAccessPrimitive(string semaphoreName, int maxConcurrentUsers)
+    {
+        if (string.IsNullOrWhiteSpace(semaphoreName))
+        {
+            throw new ArgumentException("Le nom du semaphore est obligatoire.", nameof(semaphoreName));
+        }
+
+        if (maxConcurrentUsers <= 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(maxConcurrentUsers),
+                "Le nombre maximal d'utilisateurs simultanes doit etre strictement positif.");
+        }
+
+        _maxConcurrentUsers = maxConcurrentUsers;
+        _semaphore = new Semaphore(maxConcurrentUsers, maxConcurrentUsers, semaphoreName);
+    }
+
+    /// <inheritdoc />
+    public string Name => $"semaphore({_maxConcurrentUsers})";
+
+    /// <inheritdoc />
+    public void ExecuteExclusive(Action criticalSection)
+    {
+        if (criticalSection is null)
+        {
+            throw new ArgumentNullException(nameof(criticalSection));
+        }
+
+        var hasEntered = false;
+
+        try
+        {
+            hasEntered = _semaphore.WaitOne();
+            criticalSection();
+        }
+        finally
+        {
+            if (hasEntered)
+            {
+                _semaphore.Release();
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        _semaphore.Dispose();
+    }
+}


### PR DESCRIPTION
# Gestion d'un probleme de cohorte

## Resume
Cette PR implemente la gestion de cohorte: la section `Fct_Exclusive_access` est maintenant limitee a 3 acces simultanes via un semaphore.

## Ce qui a ete fait
- Ajout du mode `semaphore` dans `ExclusiveAccessMode`.
- Mise a jour du parseur d'arguments pour accepter `--mode semaphore` et utiliser ce mode par defaut.
- Ajout de `SemaphoreCohortAccessPrimitive` avec semaphore nomme et limite de cohorte a 3.
- Mise a jour de la fabrique pour retourner la primitive de cohorte en mode `semaphore`.
- Renforcement du comptage dans `ObservationScenario` avec `Interlocked` pour les entrees/sorties de section critique.
- Ajout du suivi du maximum observe de concurrence dans la section critique.
- Affichage de la valeur maximale observee en fin d'execution.

## Verification
- Commande executee: `dotnet build WS_IPC.sln`.
- Commande executee: `dotnet run --project WS_Multithread/WS_Multithread.csproj -- --mode semaphore`.
- Observation sur une instance: valeur max observee de `_CountExclusive_access = 3`.
- Test multi-processus: deux instances lancees en parallele en mode `semaphore`.
- Observation multi-processus: occupation globale max observee de la section critique = 3.

## Perimetre
- Cette PR couvre uniquement la limitation de cohorte a 3 acces simultanes via semaphore.