### PR TITLE
Feature/Gestion d'un temps d'attente maximum

### DIFF
--- a/WS_Multithread/Program.cs
+++ b/WS_Multithread/Program.cs
@@ -3,10 +3,12 @@ using WS_Multithread.Threading;
 namespace WS_Multithread;
 
 /// <summary>
-/// Point d'entree de la feature 4 du workshop multithreading.
+/// Point d'entree de la feature 5 du workshop multithreading.
 /// </summary>
 internal static class Program
 {
+    private const int MaxExclusiveAccessWaitMilliseconds = 200;
+
     /// <summary>
     /// Lance 300 threads executant <see cref="ObservationScenario.FctA(object?)"/>.
     /// </summary>
@@ -34,7 +36,8 @@ internal static class Program
 
         IThreadScenario scenario = new ObservationScenario(
             options.SimulatedWorkDurationMilliseconds,
-            exclusiveAccessPrimitive);
+            exclusiveAccessPrimitive,
+            MaxExclusiveAccessWaitMilliseconds);
         var runner = new ThreadBatchRunner(options, scenario);
 
         runner.Run();
@@ -46,5 +49,7 @@ internal static class Program
             $"Fin d'execution. Valeur finale de _CountExclusive_access = {ObservationScenario.CurrentExclusiveAccessCount}");
         Console.WriteLine(
             $"Fin d'execution. Valeur max observee de _CountExclusive_access = {ObservationScenario.CurrentMaxExclusiveAccessCount}");
+        Console.WriteLine(
+            $"Fin d'execution. Nombre de threads impatients (attente > {MaxExclusiveAccessWaitMilliseconds} ms) = {ObservationScenario.CurrentSkippedExclusiveAccessCount}");
     }
 }

--- a/WS_Multithread/Threading/IExclusiveAccessPrimitive.cs
+++ b/WS_Multithread/Threading/IExclusiveAccessPrimitive.cs
@@ -11,8 +11,10 @@ internal interface IExclusiveAccessPrimitive : IDisposable
     string Name { get; }
 
     /// <summary>
-    /// Execute une section critique avec la strategie de synchronisation courante.
+    /// Tente d'executer une section critique avec la strategie de synchronisation courante.
     /// </summary>
     /// <param name="criticalSection">Code de la section critique.</param>
-    void ExecuteExclusive(Action criticalSection);
+    /// <param name="timeout">Temps maximal d'attente avant abandon.</param>
+    /// <returns><see langword="true"/> si la section critique a ete executee; sinon <see langword="false"/>.</returns>
+    bool TryExecuteExclusive(Action criticalSection, TimeSpan timeout);
 }

--- a/WS_Multithread/Threading/LockExclusiveAccessPrimitive.cs
+++ b/WS_Multithread/Threading/LockExclusiveAccessPrimitive.cs
@@ -11,16 +11,33 @@ internal sealed class LockExclusiveAccessPrimitive : IExclusiveAccessPrimitive
     public string Name => "lock";
 
     /// <inheritdoc />
-    public void ExecuteExclusive(Action criticalSection)
+    public bool TryExecuteExclusive(Action criticalSection, TimeSpan timeout)
     {
         if (criticalSection is null)
         {
             throw new ArgumentNullException(nameof(criticalSection));
         }
 
-        lock (_syncRoot)
+        var lockTaken = false;
+
+        try
         {
+            Monitor.TryEnter(_syncRoot, timeout, ref lockTaken);
+
+            if (!lockTaken)
+            {
+                return false;
+            }
+
             criticalSection();
+            return true;
+        }
+        finally
+        {
+            if (lockTaken)
+            {
+                Monitor.Exit(_syncRoot);
+            }
         }
     }
 

--- a/WS_Multithread/Threading/MonitorExclusiveAccessPrimitive.cs
+++ b/WS_Multithread/Threading/MonitorExclusiveAccessPrimitive.cs
@@ -11,7 +11,7 @@ internal sealed class MonitorExclusiveAccessPrimitive : IExclusiveAccessPrimitiv
     public string Name => "monitor";
 
     /// <inheritdoc />
-    public void ExecuteExclusive(Action criticalSection)
+    public bool TryExecuteExclusive(Action criticalSection, TimeSpan timeout)
     {
         if (criticalSection is null)
         {
@@ -22,8 +22,15 @@ internal sealed class MonitorExclusiveAccessPrimitive : IExclusiveAccessPrimitiv
 
         try
         {
-            Monitor.Enter(_syncRoot, ref lockTaken);
+            Monitor.TryEnter(_syncRoot, timeout, ref lockTaken);
+
+            if (!lockTaken)
+            {
+                return false;
+            }
+
             criticalSection();
+            return true;
         }
         finally
         {

--- a/WS_Multithread/Threading/MutexExclusiveAccessPrimitive.cs
+++ b/WS_Multithread/Threading/MutexExclusiveAccessPrimitive.cs
@@ -25,7 +25,7 @@ internal sealed class MutexExclusiveAccessPrimitive : IExclusiveAccessPrimitive
     public string Name => "mutex";
 
     /// <inheritdoc />
-    public void ExecuteExclusive(Action criticalSection)
+    public bool TryExecuteExclusive(Action criticalSection, TimeSpan timeout)
     {
         if (criticalSection is null)
         {
@@ -38,7 +38,7 @@ internal sealed class MutexExclusiveAccessPrimitive : IExclusiveAccessPrimitive
         {
             try
             {
-                ownsMutex = _mutex.WaitOne();
+                ownsMutex = _mutex.WaitOne(timeout);
             }
             catch (AbandonedMutexException)
             {
@@ -46,7 +46,13 @@ internal sealed class MutexExclusiveAccessPrimitive : IExclusiveAccessPrimitive
                 ownsMutex = true;
             }
 
+            if (!ownsMutex)
+            {
+                return false;
+            }
+
             criticalSection();
+            return true;
         }
         finally
         {

--- a/WS_Multithread/Threading/NoSynchronizationExclusiveAccessPrimitive.cs
+++ b/WS_Multithread/Threading/NoSynchronizationExclusiveAccessPrimitive.cs
@@ -9,7 +9,7 @@ internal sealed class NoSynchronizationExclusiveAccessPrimitive : IExclusiveAcce
     public string Name => "none";
 
     /// <inheritdoc />
-    public void ExecuteExclusive(Action criticalSection)
+    public bool TryExecuteExclusive(Action criticalSection, TimeSpan timeout)
     {
         if (criticalSection is null)
         {
@@ -17,6 +17,7 @@ internal sealed class NoSynchronizationExclusiveAccessPrimitive : IExclusiveAcce
         }
 
         criticalSection();
+        return true;
     }
 
     /// <inheritdoc />

--- a/WS_Multithread/Threading/ObservationScenario.cs
+++ b/WS_Multithread/Threading/ObservationScenario.cs
@@ -15,8 +15,10 @@ internal sealed class ObservationScenario : IThreadScenario
     /// </summary>
     private static int _CountExclusive_access = 0;
     private static int _MaxCountExclusive_access = 0;
+    private static int _SkippedExclusiveAccessCount = 0;
 
     private static int _simulatedWorkDurationMilliseconds = 30;
+    private static int _maxExclusiveAccessWaitMilliseconds = 200;
     private static IExclusiveAccessPrimitive? _exclusiveAccessPrimitive;
 
     /// <summary>
@@ -24,9 +26,11 @@ internal sealed class ObservationScenario : IThreadScenario
     /// </summary>
     /// <param name="simulatedWorkDurationMilliseconds">Delai simule dans la methode FctA.</param>
     /// <param name="exclusiveAccessPrimitive">Primitive de synchronisation a utiliser pour l'acces exclusif.</param>
+    /// <param name="maxExclusiveAccessWaitMilliseconds">Temps d'attente maximal avant abandon de la section controlee.</param>
     public ObservationScenario(
         int simulatedWorkDurationMilliseconds,
-        IExclusiveAccessPrimitive exclusiveAccessPrimitive)
+        IExclusiveAccessPrimitive exclusiveAccessPrimitive,
+        int maxExclusiveAccessWaitMilliseconds)
     {
         if (simulatedWorkDurationMilliseconds < 0)
         {
@@ -35,9 +39,17 @@ internal sealed class ObservationScenario : IThreadScenario
                 "Le delai de travail simule ne peut pas etre negatif.");
         }
 
+        if (maxExclusiveAccessWaitMilliseconds < 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(maxExclusiveAccessWaitMilliseconds),
+                "Le delai d'attente maximal ne peut pas etre negatif.");
+        }
+
         _exclusiveAccessPrimitive = exclusiveAccessPrimitive
             ?? throw new ArgumentNullException(nameof(exclusiveAccessPrimitive));
         _simulatedWorkDurationMilliseconds = simulatedWorkDurationMilliseconds;
+        _maxExclusiveAccessWaitMilliseconds = maxExclusiveAccessWaitMilliseconds;
     }
 
     /// <summary>
@@ -56,6 +68,11 @@ internal sealed class ObservationScenario : IThreadScenario
     public static int CurrentMaxExclusiveAccessCount => Interlocked.CompareExchange(ref _MaxCountExclusive_access, 0, 0);
 
     /// <summary>
+    /// Obtient le nombre de threads ayant abandonne l'acces apres expiration du delai d'attente.
+    /// </summary>
+    public static int CurrentSkippedExclusiveAccessCount => Interlocked.CompareExchange(ref _SkippedExclusiveAccessCount, 0, 0);
+
+    /// <summary>
     /// Reinitialise le compteur partage.
     /// </summary>
     public static void ResetCounter()
@@ -70,6 +87,7 @@ internal sealed class ObservationScenario : IThreadScenario
     {
         Interlocked.Exchange(ref _CountExclusive_access, 0);
         Interlocked.Exchange(ref _MaxCountExclusive_access, 0);
+        Interlocked.Exchange(ref _SkippedExclusiveAccessCount, 0);
     }
 
     /// <inheritdoc />
@@ -100,14 +118,15 @@ internal sealed class ObservationScenario : IThreadScenario
 
     /// <summary>
     /// Section de code avec acces controle.
+    /// Un thread abandonne si l'attente depasse la limite configuree.
     /// </summary>
     /// <param name="threadName">Nom logique du thread.</param>
     public static void Fct_Exclusive_access(string threadName)
     {
         var exclusiveAccessPrimitive = _exclusiveAccessPrimitive
             ?? throw new InvalidOperationException("La primitive d'acces exclusif n'est pas configuree.");
-
-        exclusiveAccessPrimitive.ExecuteExclusive(
+        var timeout = TimeSpan.FromMilliseconds(_maxExclusiveAccessWaitMilliseconds);
+        var hasExecuted = exclusiveAccessPrimitive.TryExecuteExclusive(
             () =>
             {
                 var countAfterEnter = Interlocked.Increment(ref _CountExclusive_access);
@@ -125,7 +144,15 @@ internal sealed class ObservationScenario : IThreadScenario
                     Console.WriteLine(
                         $"[{DateTime.UtcNow:HH:mm:ss.fff}] P{Environment.ProcessId} {threadName} EXIT  - exclusive count: {countAfterExit}");
                 }
-            });
+            },
+            timeout);
+
+        if (!hasExecuted)
+        {
+            var skippedCount = Interlocked.Increment(ref _SkippedExclusiveAccessCount);
+            Console.WriteLine(
+                $"[{DateTime.UtcNow:HH:mm:ss.fff}] P{Environment.ProcessId} {threadName} SKIP  - attente > {_maxExclusiveAccessWaitMilliseconds} ms (skipped: {skippedCount})");
+        }
     }
 
     private static void UpdateMaxExclusiveAccessCount(int candidate)

--- a/WS_Multithread/Threading/SemaphoreCohortAccessPrimitive.cs
+++ b/WS_Multithread/Threading/SemaphoreCohortAccessPrimitive.cs
@@ -35,7 +35,7 @@ internal sealed class SemaphoreCohortAccessPrimitive : IExclusiveAccessPrimitive
     public string Name => $"semaphore({_maxConcurrentUsers})";
 
     /// <inheritdoc />
-    public void ExecuteExclusive(Action criticalSection)
+    public bool TryExecuteExclusive(Action criticalSection, TimeSpan timeout)
     {
         if (criticalSection is null)
         {
@@ -46,8 +46,15 @@ internal sealed class SemaphoreCohortAccessPrimitive : IExclusiveAccessPrimitive
 
         try
         {
-            hasEntered = _semaphore.WaitOne();
+            hasEntered = _semaphore.WaitOne(timeout);
+
+            if (!hasEntered)
+            {
+                return false;
+            }
+
             criticalSection();
+            return true;
         }
         finally
         {


### PR DESCRIPTION
# Gestion d'un temps d'attente maximum

## Resume
Cette PR ajoute une attente maximale de 200 ms pour l'acces a `Fct_Exclusive_access`. Si la ressource n'est pas obtenue a temps, le thread abandonne cette section et poursuit son execution.

## Ce qui a ete fait
- Evolution de l'interface `IExclusiveAccessPrimitive` avec `TryExecuteExclusive(Action, TimeSpan)`.
- Implementation du timeout dans toutes les primitives:
- `NoSynchronizationExclusiveAccessPrimitive`.
- `LockExclusiveAccessPrimitive`.
- `MonitorExclusiveAccessPrimitive`.
- `MutexExclusiveAccessPrimitive`.
- `SemaphoreCohortAccessPrimitive`.
- Mise a jour de `ObservationScenario`:
- ajout de la configuration d'attente maximale (`200 ms`),
- abandon de la section controlee si le timeout est atteint,
- journalisation `SKIP` lors d'un abandon,
- ajout du compteur de threads impatients.
- Mise a jour de `Program` pour passer la valeur `200 ms` et afficher le total des abandons en fin d'execution.

## Verification
- Commande executee: `dotnet build WS_IPC.sln`.
- Commande executee: `dotnet run --project WS_Multithread/WS_Multithread.csproj -- --mode mutex`.
- Observation: des threads abandonnent correctement l'acces apres 200 ms (`Nombre de threads impatients = 149` observe).
- Commande executee: `dotnet run --project WS_Multithread/WS_Multithread.csproj -- --mode semaphore`.
- Observation: execution sans abandon dans ce profil de charge (`Nombre de threads impatients = 0` observe).

## Perimetre
- Cette PR couvre uniquement la gestion du temps d'attente maximal avant abandon de la section controlee.