### PR TITLE
feature/Gestion de la fin d'execution des threads

### DIFF
--- a/WS_Multithread/Program.cs
+++ b/WS_Multithread/Program.cs
@@ -3,7 +3,7 @@ using WS_Multithread.Threading;
 namespace WS_Multithread;
 
 /// <summary>
-/// Point d'entree de la feature 5 du workshop multithreading.
+/// Point d'entree de la feature 6 du workshop multithreading.
 /// </summary>
 internal static class Program
 {
@@ -32,15 +32,21 @@ internal static class Program
         ObservationScenario.ResetCounter();
         ObservationScenario.ResetExclusiveAccessCounter();
 
+        using var completionEvent = new CountdownEvent(options.ThreadCount);
+
         Console.WriteLine($"Mode d'acces exclusif: {exclusiveAccessPrimitive.Name}");
 
-        IThreadScenario scenario = new ObservationScenario(
+        IThreadScenario businessScenario = new ObservationScenario(
             options.SimulatedWorkDurationMilliseconds,
             exclusiveAccessPrimitive,
             MaxExclusiveAccessWaitMilliseconds);
+        IThreadScenario scenario = new CountdownSignalingScenarioDecorator(
+            businessScenario,
+            completionEvent);
         var runner = new ThreadBatchRunner(options, scenario);
 
         runner.Run();
+        completionEvent.Wait();
 
         Console.WriteLine();
         Console.WriteLine(

--- a/WS_Multithread/Threading/CountdownSignalingScenarioDecorator.cs
+++ b/WS_Multithread/Threading/CountdownSignalingScenarioDecorator.cs
@@ -1,0 +1,34 @@
+namespace WS_Multithread.Threading;
+
+/// <summary>
+/// Signale un <see cref="CountdownEvent"/> a la fin de chaque execution de thread.
+/// </summary>
+internal sealed class CountdownSignalingScenarioDecorator : IThreadScenario
+{
+    private readonly IThreadScenario _innerScenario;
+    private readonly CountdownEvent _completionEvent;
+
+    /// <summary>
+    /// Initialise une nouvelle instance de <see cref="CountdownSignalingScenarioDecorator"/>.
+    /// </summary>
+    /// <param name="innerScenario">Scenario metier execute par le thread.</param>
+    /// <param name="completionEvent">Compteur de synchronisation a decremeter en fin de traitement.</param>
+    public CountdownSignalingScenarioDecorator(IThreadScenario innerScenario, CountdownEvent completionEvent)
+    {
+        _innerScenario = innerScenario ?? throw new ArgumentNullException(nameof(innerScenario));
+        _completionEvent = completionEvent ?? throw new ArgumentNullException(nameof(completionEvent));
+    }
+
+    /// <inheritdoc />
+    public void Execute(object? threadState)
+    {
+        try
+        {
+            _innerScenario.Execute(threadState);
+        }
+        finally
+        {
+            _completionEvent.Signal();
+        }
+    }
+}

--- a/WS_Multithread/Threading/ThreadBatchRunner.cs
+++ b/WS_Multithread/Threading/ThreadBatchRunner.cs
@@ -1,7 +1,7 @@
 namespace WS_Multithread.Threading;
 
 /// <summary>
-/// Orchestre le lancement et l'attente d'un lot de threads.
+/// Orchestre le lancement d'un lot de threads.
 /// </summary>
 internal sealed class ThreadBatchRunner
 {
@@ -20,12 +20,10 @@ internal sealed class ThreadBatchRunner
     }
 
     /// <summary>
-    /// Lance tous les threads puis attend leur fin d'execution.
+    /// Lance tous les threads.
     /// </summary>
     public void Run()
     {
-        var threads = new List<Thread>(_options.ThreadCount);
-
         for (var index = 1; index <= _options.ThreadCount; index++)
         {
             var threadName = $"Thread_{index:D3}";
@@ -34,18 +32,12 @@ internal sealed class ThreadBatchRunner
                 Name = threadName
             };
 
-            threads.Add(thread);
             thread.Start(threadName);
 
             if (_options.DelayBetweenStartsMilliseconds > 0)
             {
                 Thread.Sleep(_options.DelayBetweenStartsMilliseconds);
             }
-        }
-
-        foreach (var thread in threads)
-        {
-            thread.Join();
         }
     }
 }


### PR DESCRIPTION
# Gestion de la fin d'execution des threads

## Resume
Cette PR met en place l'attente de fin de tous les threads avec `CountdownEvent` dans `Main`.

## Ce qui a ete fait
- Ajout du decorateur `CountdownSignalingScenarioDecorator` pour signaler la fin de chaque thread.
- Le signalement est effectue dans un `finally` pour garantir la decrementation du compteur de terminaison.
- Mise a jour de `Program`:
- creation d'un `CountdownEvent` initialise avec `ThreadCount`,
- encapsulation du scenario metier avec le decorateur de signalement,
- attente explicite de fin via `completionEvent.Wait()`.
- Mise a jour de `ThreadBatchRunner` pour se limiter au lancement des threads.

## Verification
- Commande executee: `dotnet build WS_IPC.sln`.
- Commande executee: `dotnet run --project WS_Multithread/WS_Multithread.csproj`.
- Observation: le programme attend correctement la fin de tous les threads avant d'afficher les valeurs finales.

## Perimetre
- Cette PR couvre uniquement la synchronisation de fin d'execution via `CountdownEvent`.